### PR TITLE
Use homebrew based ports of GNU tools find and readlink if on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Once you've setup the templates you'd like to use, you're ready to set a theme.
 base16-manager install materia
 ```
 
+### For Mac users
+If you are a Mac user you need to install [Homebrew](https://brew.sh/index_se.html) and then install the appropriate GNU utils as below.
+```sh
+brew install coreutils
+brew install findutils
+```
+
 ## Usage
 ```sh
 Usage: base16-manager [option]

--- a/base16-manager
+++ b/base16-manager
@@ -2,8 +2,16 @@
 #
 # Install base16 templates and set themes globally.
 
+is_mac() {
+  [[ "$(uname)" == "Darwin" ]]
+}
+
 readonly SCRIPT_NAME="$0"
-readonly SCRIPT=$(readlink -f "${SCRIPT_NAME}")
+if ! is_mac; then
+  readonly SCRIPT=$(readlink -f "${SCRIPT_NAME}")
+else
+  readonly SCRIPT=$(greadlink -f "${SCRIPT_NAME}")
+fi
 readonly SCRIPT_PATH=$(dirname ${SCRIPT})
 readonly CONFIG_PATH="${HOME}/.base16-manager"
 
@@ -76,7 +84,11 @@ uninstall() {
 }
 
 list() {
-  find ${CONFIG_PATH} -maxdepth 2 -mindepth 2 -type d -printf "%P\n"
+  if ! is_mac; then
+    find ${CONFIG_PATH} -maxdepth 2 -mindepth 2 -type d -printf "%P\n"
+  else
+    gfind ${CONFIG_PATH} -maxdepth 2 -mindepth 2 -type d -printf "%P\n"
+  fi
 }
 
 update() {


### PR DESCRIPTION
Not sure if you intend this to be portable. If not, feel free to ignore my humble pull request :)

On macOS it seems the `-f` flag for `readlink` ([more info](https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac)) and the `-printf` flag for `find` ([more info](
https://stackoverflow.com/questions/752818/find-lacks-the-option-printf-now-what)) are not available. `base16-manager` thus fails like this:

```sh
readlink: illegal option -- f
usage: readlink [-n] [file ...]
usage: dirname path
find: -printf: unknown primary or operator
```

However, the GNU versions of the utils can be installed via Homebrew like this:
```sh
brew install coreutils
brew install findutils
```

Which means that mac users can use `gfind` instead of `find` and `greadlink` instead of `readlink` and get the expected behavior. This is what the PR does.

Apologies for introducing `if` statements rather than finding alternative ways of solving the problem  but that's all I had time for at the moment :)

This PR makes me able to run all commands on macOS Sierra. However, it should be noted that when doing `base16-manager set monokai` I'm seeing the following errors:
```sh
touch: /Users/chris/.config/fish/config.fish: No such file or directory
sed: /Users/chris/.config/fish/config.fish: No such file or directory
mv: rename /Users/chris/.config/fish/config.fish to /Users/chris/.config/fish/config.fish.bac: No such file or directory
mv: rename /tmp/fish_config to /Users/chris/.config/fish/config.fish: No such file or directory
./base16-manager: line 225: /Users/chris/.config/fish/config.fish: No such file or directory
Set theme to monokai. You may need to restart DE and terminals.
```
However, I would humbly suggest that that be handled in a separate commit and PR since these seem fish related, and since I am now experiencing the expected behavior apart from these errors.