### PR TITLE
Use regex instead of -printf in list-themes 

### DIFF
--- a/base16-manager
+++ b/base16-manager
@@ -94,9 +94,9 @@ list() {
 }
 
 list_themes() {
-  find ${CONFIG_PATH} -type f -name 'base16-*' -printf "%f\n" | \
+  find ${CONFIG_PATH} -type f -name 'base16-*' | \
+    sed "s/.*\/base16-//" | \
     sed "s/\..*//" | \
-    sed "s/base16-//" | \
     sort | uniq
 }
 


### PR DESCRIPTION
Since `-printf` is not available on the `find` command on macOS.

Could use `gfind` (installed via Homebrew as mentioned in f8e54dbc7e96a3451096fa50039a5a95d10ff243 since that command behaves like GNUs `find` and thus has the `-printf` flag) but that requires an if-statement and I figured this is a cleaner solution. Makes sense?