### PR TITLE
Modify set_fzf() to only append config line

### DIFF
--- a/base16-manager
+++ b/base16-manager
@@ -206,11 +206,7 @@ set_fzf() {
     cp "${file}" "${HOME}/.fzf.colors"
 
     for config in ${configs}; do
-      if ! file_exists "${HOME}/${config}"; then
-        touch "${HOME}/${config}"
-      fi
-
-      if ! grep -Fxq "${line}" "${HOME}/${config}"; then
+      if file_exists "${HOME}/${config}" && ! grep -Fxq "${line}" "${HOME}/${config}"; then
         echo "${line}" >> "${HOME}/${config}"
       fi
     done


### PR DESCRIPTION
Don't create the config files that don't exist. For example if the user
does not have fish installed then the touch command will fail as there
will be no .config/fish dir.