### PR TITLE
Add set-random command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $ base16-manager set materia
 Usage: base16-manager [option]
 Options:
     set          'base16-theme'         Sets the theme
+    set-random                          Sets to a random installed theme
     install      'username/repository'  Installs a new template
     uninstall    'username/repository'  Uninstalls a template
     list                                Lists installed templates

--- a/base16-manager
+++ b/base16-manager
@@ -23,6 +23,7 @@ usage() {
   echo "Usage: base16-manager [option]"
   echo "Options:"
   echo "    set          'base16-theme'         Sets the theme"
+  echo "    set-random                          Sets to a random installed theme"
   echo "    install      'username/repository'  Installs a new template"
   echo "    uninstall    'username/repository'  Uninstalls a template"
   echo "    list                                Lists installed templates"
@@ -94,10 +95,12 @@ list() {
 }
 
 list_themes() {
+  local sort_option=$1
+
   find ${CONFIG_PATH} -type f -name 'base16-*' | \
     sed "s/.*\/base16-//" | \
     sed "s/\..*//" | \
-    sort | uniq
+    sort $sort_option | uniq
 }
 
 update() {
@@ -286,6 +289,10 @@ set_vim() {
   fi
 }
 
+set_random() {
+  set_theme $(list_themes -R | head -n1 | awk "{print $1;}")
+}
+
 set_xresources() {
   local package=$1
   local theme=$2
@@ -339,6 +346,9 @@ main() {
       ;;
     "self-update")
       self_update
+      ;;
+    "set-random")
+      set_random
       ;;
     *)
       usage


### PR DESCRIPTION
A fun command to have. I like changing my themes often want something new and different. Running `base16-manager set-random` will call `set` with a random theme from list-themes.

* Passes -R to the list-themes sort command to pick a random theme from the available themes.