### PR TITLE
Add Zathura

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ Options:
 * [khamer/base16-dunst](https://github.com/khamer/base16-dunst)
 * [khamer/base16-termite](https://github.com/khamer/base16-termite)
 * [nicodebo/base16-fzf](https://github.com/nicodebo/base16-fzf)
+* [nicodebo/base16-zathura](https://github.com/nicodebo/base16-zathura)
 * [theova/base16-qutebrowser](https://github.com/theova/base16-qutebrowser)

--- a/base16-manager
+++ b/base16-manager
@@ -116,6 +116,7 @@ list_support() {
   echo "khamer/base16-dunst"
   echo "khamer/base16-termite"
   echo "nicodebo/base16-fzf"
+  echo "nicodebo/base16-zathura"
   echo "theova/base16-qutebrowser"
 }
 
@@ -186,6 +187,10 @@ set_theme() {
         ;;
       "nicodebo/base16-fzf")
         set_fzf "${package}" "${theme}"
+        ;;
+      "nicodebo/base16-zathura")
+        set_generic "${package}" "${theme}" "#" ' ' \
+          "$HOME/.config/zathura/config"
         ;;
       "khamer/base16-termite")
         set_generic "${package}" "${theme}" "#" "=" "$HOME/.config/termite/config"

--- a/base16-manager
+++ b/base16-manager
@@ -190,7 +190,7 @@ set_theme() {
         ;;
       "nicodebo/base16-zathura")
         set_generic "${package}" "${theme}" "#" ' ' \
-          "$HOME/.config/zathura/config"
+          "$HOME/.config/zathura/zathurarc"
         ;;
       "khamer/base16-termite")
         set_generic "${package}" "${theme}" "#" "=" "$HOME/.config/termite/config"


### PR DESCRIPTION
Add support for  [zathura](https://pwmt.org/projects/zathura/) by using [nicodebo/base16-zathura](https://github.com/nicodebo/base16-zathura).

Depends on #32. 