### PR TITLE
Preserve transparency in Termite configurations

### DIFF
--- a/base16-manager
+++ b/base16-manager
@@ -284,7 +284,11 @@ set_theme() {
           "$HOME/.config/zathura/zathurarc"
         ;;
       "khamer/base16-termite")
+        termite_transp=$(grep -Po 'background\s*=\s*rgba\(\d+,\s*\d+,\s*\d+,\s*\K[\.0-9]+' $HOME/.config/termite/config)
         set_generic "$package" "$theme" "#" "=" "$HOME/.config/termite/config"
+        if [[ -n "$termite_transp" ]]; then
+          sed -i 's/\(background\s*=\s*rgba(.*\))/\1, '"$termite_transp"')/' $HOME/.config/termite/config
+        fi
         killall -USR1 termite  # Reload termite configuration in-place.
         ;;
       "theova/base16-qutebrowser")


### PR DESCRIPTION
Transparency in Termite is set via the `background` option, which base16-manager overrides. This PR will detect if transparency is set (a fourth parameter is specified for rgba) and re-add it after base16-manager modifies `background`. This "works for me," but this approach has some caveats:

* Only works with Termite and not other packages using `set_generic`
* Makes use of PCRE in grep, which may not be available on some lightweight distros (e.g., busybox/Alpine)