### PR TITLE
Added custom method for setting Zathura colors.

### DIFF
--- a/base16-manager
+++ b/base16-manager
@@ -448,8 +448,8 @@ set_qutebrowser() {
 
   # add new line to include colors to Xresources
   line_in_file "$quterc" \
-               "^config.source(\"qute_colors.py\")\\s*$" \
-               "config.source(\"qute_colors.py\")"
+               "^config\.source\(\"qute_colors.py\"\)\\s*$" \
+               "config\.source(\"qute_colors.py\")"
 }
 
 set_zathura() {

--- a/base16-manager
+++ b/base16-manager
@@ -200,7 +200,7 @@ list_support() {
   echo "khamer/base16-dunst"
   echo "khamer/base16-termite"
   echo "nicodebo/base16-fzf"
-  echo "nicodebo/base16-zathura"
+  echo "HaoZeke/base16-zathura"
   echo "theova/base16-qutebrowser"
   echo "rkubosz/base16-sway"
 }
@@ -279,7 +279,7 @@ set_theme() {
       "nicodebo/base16-fzf")
         set_fzf "$package" "$theme"
         ;;
-      "nicodebo/base16-zathura")
+      "HaoZeke/base16-zathura")
         set_zathura "$package" "$theme" 
         ;;
       "khamer/base16-termite")
@@ -460,8 +460,8 @@ set_zathura() {
   local zathura_colors="$configd/zathura_colors"
 
   # get template and handling for inexisting templates
-  if ls "$DATA_PATH/$package"/*/"base16-$theme."* &>/dev/null; then
-    file=$(ls "$DATA_PATH/$package"/*/"base16-$theme."* )
+  if ls "$DATA_PATH/$package"/*/"colors/base16-$theme."* &>/dev/null; then
+    file=$(ls "$DATA_PATH/$package"/*/"colors/base16-$theme."* )
   else
     err "$package: theme $theme not found."
     return 1

--- a/base16-manager
+++ b/base16-manager
@@ -280,8 +280,7 @@ set_theme() {
         set_fzf "$package" "$theme"
         ;;
       "nicodebo/base16-zathura")
-        set_generic "$package" "$theme" "#" ' ' \
-          "$HOME/.config/zathura/zathurarc"
+        set_zathura "$package" "$theme" 
         ;;
       "khamer/base16-termite")
         set_generic "$package" "$theme" "#" "=" "$HOME/.config/termite/config"
@@ -423,6 +422,35 @@ set_by_copy() {
   # copy template to the config location.
   cp "$file" "$config"
 }
+
+set_zathura() {
+  local package=$1
+  local theme=$2
+  local configd="$HOME/.config/zathura/"
+  local zathurarc="$configd/zathurarc"
+  local zathura_colors="$configd/zathura_colors"
+  local file="$DATA_PATH/$package/xresources/base16-$theme.Xresources"
+
+  # get template and handling for inexisting templates
+  if ls "$DATA_PATH/$package"/*/"base16-$theme."* &>/dev/null; then
+    file=$(ls "$DATA_PATH/$package"/*/"base16-$theme."* )
+  else
+    err "$package: theme $theme not found."
+    return 1
+  fi
+
+  if [ -f $zathura_colors ]; then
+      mv $zathura_colors "$zathura_colors.bac"
+  fi
+  
+  cp $file $zathura_colors
+
+  # add new line to include colors to Xresources
+  line_in_file "$zathurarc" \
+               "^include\\s+\"zathura_colors\"$" \
+               "include \"zathura_colors\""
+}
+
 
 set_dunst() {
   local package=$1

--- a/base16-manager
+++ b/base16-manager
@@ -289,16 +289,17 @@ set_theme() {
       "theova/base16-qutebrowser")
         # handle different locations of config
         if is_mac; then
-          QUTEBROWSERCONF="$HOME/.qutebrowser/config.py"
+          QUTEBROWSERDIR="$HOME/.qutebrowser/"
         elif is_linux; then
-          QUTEBROWSERCONF="$HOME/.config/qutebrowser/config.py"
+          QUTEBROWSERDIR="$HOME/.config/qutebrowser/"
         else
           bug "Unkown OS: $(uname)"
           return
         fi
 
         # set theme
-        set_generic "$package" "$theme" "#" "=" "$QUTEBROWSERCONF"
+        # set_generic "$package" "$theme" "#" "=" "$QUTEBROWSERCONF"
+        set_qutebrowser "$package" "$theme" "$QUTEBROWSERDIR"
         ;;
       "rkubosz/base16-sway")
         set_by_copy "$package" "$theme" "$HOME/.config/sway/colorscheme" "config"
@@ -423,13 +424,40 @@ set_by_copy() {
   cp "$file" "$config"
 }
 
+set_qutebrowser() {
+  local package=$1
+  local theme=$2
+  local configd=$3
+  local quterc="$configd/config.py"
+  local qute_colors="$configd/qute_colors.py"
+  local theme_type="default"    # "default" or "minimal"
+
+  # get template and handling for inexisting templates
+  if ls "$DATA_PATH/$package"/*/"$theme_type/base16-$theme."* &>/dev/null; then
+    file=$(ls "$DATA_PATH/$package"/*/"$theme_type/base16-$theme."* )
+  else
+    err "$package: theme $theme not found."
+    return 1
+  fi
+
+  if [ -f $qute_colors ]; then
+      mv $qute_colors "$qute_colors.bac"
+  fi
+  
+  cp $file $qute_colors
+
+  # add new line to include colors to Xresources
+  line_in_file "$quterc" \
+               "^config.source(\"qute_colors.py\")\\s*$" \
+               "config.source(\"qute_colors.py\")"
+}
+
 set_zathura() {
   local package=$1
   local theme=$2
   local configd="$HOME/.config/zathura/"
   local zathurarc="$configd/zathurarc"
   local zathura_colors="$configd/zathura_colors"
-  local file="$DATA_PATH/$package/xresources/base16-$theme.Xresources"
 
   # get template and handling for inexisting templates
   if ls "$DATA_PATH/$package"/*/"base16-$theme."* &>/dev/null; then


### PR DESCRIPTION
The set_generic() method wipes out the user's exsiting zathura
configuration, replacing it with just the color definitions!

set_zathura() leaves the user's zathura config intact and includes a
colors file instead. This is similar to what set_xresources() does to
the .Xresources file.