### PR TITLE
Fixes for: set_rofi - set_dunst - set_fzf - set_shell & fish completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ BASHCOMP=completion/completion.bash
 BASHCOMPDIR=${PREFIX}/share/bash-completion/completions
 ZSHCOMP=completion/completion.zsh
 ZSHCOMPDIR=${PREFIX}/share/zsh/site-functions/
+FISHCOMP=completion/completion.fish
+FISHCOMPDIR=${PREFIX}/share/fish/vendor_completions.d/
 
 install:
 	install -D -m755 ${TARGET} ${DESTDIR}${BINDIR}/${TARGET}
@@ -24,8 +26,15 @@ install:
 	install -D -m644 ${ZSHCOMP} ${DESTDIR}${ZSHCOMPDIR}/_base16-manager; \
 	fi;
 
+	@if [[ -d ${FISHCOMPDIR} ]] ; \
+	then \
+	echo "install completion for fish"; \
+	install -D -m644 ${FISHCOMP} ${DESTDIR}${FISHCOMPDIR}/base16-manager.fish; \
+	fi;
+
 clean:
 	rm -f ${DESTDIR}${BINDIR}/${TARGET}
 	rm -f ${DESTDIR}${LICENSEDIR}/${TARGET}/LICENSE
 	rm -f ${DESTDIR}${BASHCOMPDIR}/base16-manager
 	rm -f ${DESTDIR}${ZSHCOMPDIR}/_base16-manager
+	rm -f ${DESTDIR}${FISHCOMPDIR}/base16-manager.fish

--- a/base16-manager
+++ b/base16-manager
@@ -446,27 +446,41 @@ set_dunst() {
 set_fzf() {
   local package=$1
   local theme=$2
-  local file=""
-  local line="[ -f ~/.fzf.colors ] && source ~/.fzf.colors"
-  local configs=".bashrc .zshrc .config/fish/config.fish"
+  local theme_files=(
+    "$HOME/.fzf.colors" # bash
+    "$HOME/.fzf.colors" # zsh
+    "$HOME/.fzf.colors.fish" # fish
+  )
+  local config_lines=(
+    "[ -f ~/.fzf.colors ] && source ~/.fzf.colors" # bash
+    "[ -f ~/.fzf.colors ] && source ~/.fzf.colors" # zsh
+    "[ -f ~/.fzf.colors.fish ] && source ~/.fzf.colors.fish" # fish
+  )
+  local configs=(
+    ".bashrc" # bash
+    ".zshrc" # zsh
+    ".config/fish/config.fish" # fish
+  )
+  local files=(
+    "$DATA_PATH/$package/bash/base16-$theme.config" # bash
+    "$DATA_PATH/$package/bash/base16-$theme.config" # zsh
+    "$DATA_PATH/$package/fish/base16-$theme.fish" # fish
+  )
 
-  if command -v fish >/dev/null 2>&1; then
-    file="$DATA_PATH/$package/fish/base16-$theme.fish"
-  else
-    file="$DATA_PATH/$package/bash/base16-$theme.config"
-  fi
-
-  if ! file_exists "$file"; then
-    err "FZF theme not found."
-  else
-    cp "$file" "$HOME/.fzf.colors"
-
-    for config in $configs; do
-      if file_exists "$HOME/$config" && ! grep -Fxq "$line" "$HOME/$config"; then
-        echo "$line" >> "$HOME/$config"
+  for i in ${!configs[@]}; do
+    theme_file=${theme_files[$i]}
+    config=${configs[$i]}
+    config_line=${config_lines[$i]}
+    file=${files[$i]}
+    if ! file_exists "$file"; then
+      err "FZF theme not found."
+    else
+      cp "$file" "$theme_file"
+      if file_exists "$HOME/$config" && ! grep -Fxq "$config_line" "$HOME/$config"; then
+        echo "$config_line" >> "$HOME/$config"
       fi
-    done
-  fi
+    fi
+  done
 }
 
 set_shell() {

--- a/base16-manager
+++ b/base16-manager
@@ -491,9 +491,9 @@ set_shell() {
   local fish_dir="$HOME/.config/fish"
   local fish_config="$fish_dir/config.fish"
   local fish_string="# Base16 Shell
-  if status --is-interactive
-    eval sh $file
-  end"
+if status --is-interactive
+  eval sh $file
+end"
 
   if ! file_exists "$helper"; then
     err "Shell helper not found."

--- a/base16-manager
+++ b/base16-manager
@@ -530,8 +530,8 @@ set_rofi() {
   local theme=$2
 
   # get template and handling for inexisting templates
-  if ls "$DATA_PATH/$package"/*/"base16-$theme."* &>/dev/null; then
-    file=$(ls "$DATA_PATH/$package"/*/"base16-$theme."*"rasi" )
+  if ls "$DATA_PATH/$package/themes/base16-$theme."* &>/dev/null; then
+    file=$(ls "$DATA_PATH/$package/themes/base16-$theme."*"rasi" )
   else
     err "$package: theme $theme not found."
     return 1

--- a/base16-manager
+++ b/base16-manager
@@ -433,7 +433,7 @@ set_dunst() {
   if ! file_exists "$file"; then
     err "Dunst theme not found."
   else
-    sed '/^\[base16_low\]$/,/^\s+foreground(.*)$/d' "$config" > /tmp/dunstrc
+    sed '/^frame_color = .*$/,/^\s+foreground(.*)$/d' "$config" > /tmp/dunstrc
     [[ -f "$config.bac" ]] && rm "$config.bac"
     mv "$config" "$config.bac"
     cat /tmp/dunstrc "$file" > "$config"

--- a/completion/completion.fish
+++ b/completion/completion.fish
@@ -1,0 +1,17 @@
+# fish completions for base16-manager
+
+# Get description of commands listed in --help
+set -l base16_manager_commands_help (base16-manager --help | sed 1,2d | sed 's/   */,/g' | rev | cut -s -d ',' -f 1 | rev)
+set -l base16_manager_commands (base16-manager usage-short)
+set -l i 1
+for command in $base16_manager_commands
+    complete -f -c base16-manager -n "not __fish_seen_subcommand_from $base16_manager_commands" -a "$command" -d "$base16_manager_commands_help[$i]"
+    set -l i (math $i + 1)
+end
+
+# Never complete with filename
+complete -f -c base16-manager
+
+complete -f -c base16-manager -n "__fish_seen_subcommand_from set; and test (count (commandline -opc)) -eq 2" -a "(base16-manager list-themes)"
+complete -f -c base16-manager -n "__fish_seen_subcommand_from install; and test (count (commandline -opc)) -eq 2" -a "(base16-manager list-installable)"
+complete -f -c base16-manager -n "__fish_seen_subcommand_from uninstall; and test (count (commandline -opc)) -eq 2" -a "(base16-manager list)"


### PR DESCRIPTION
**Fish**
Adding command completions for the Fish shell. I tried locally with all the commands.

**set_rofi**
An extra config line was being added and messing with the config.
It looks like this pull request in `base16-rofi` introduced the issue: https://github.com/0xdec/base16-rofi/pull/12

**set_dunst**
Themes contains two extra lines that were not taken into account when updating theme

**set_fzf**
Setting values in fish is different than in bash, the fzf themes are not compatible between shells.
Fixed that.

**set_shell**
Some extra indentation were added in the fish config file

More details in the commits messages

Sorry for the multiple edits of the pull request. I ended up fixing all the pending issues I had at once.
Thanks for base16-manager!