### PR TITLE
fix: Makefile not targeting bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 TARGET=base16-manager
 PREFIX=/usr
 DESTDIR=


### PR DESCRIPTION
The error I was seeing was  '/bin/sh: 1: [[; not found', I assume other systems have sh symlinked to bash.